### PR TITLE
invalidate all files

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
 
 #    FOR DEBUGGING UNCOMMENT THE PULL REQUEST LINES SO YOU CAN TEST IN A PR RATHER THEN MERGE
-  pull_request:
-    branches: []
+#  pull_request:
+#    branches: []
 
 
 jobs:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
 
 #    FOR DEBUGGING UNCOMMENT THE PULL REQUEST LINES SO YOU CAN TEST IN A PR RATHER THEN MERGE
-#  pull_request:
-#    branches: []
+  pull_request:
+    branches: []
 
 
 jobs:
@@ -60,7 +60,7 @@ jobs:
       - uses: chetan/invalidate-cloudfront-action@v2
         env:
           DISTRIBUTION: ${{ secrets.AWS_DISTRIBUTION }}
-          PATHS: "/index.html"
+          PATHS: "/*"
           AWS_REGION: "ap-southeast-2"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
currently it is set to invalidate all the files in the bucket on every pr to main. 
This will mean.
- the entire s3 bucket is deleted and recreated
-  Cloudfront will revalidate the entire project and distribute it (cloudfront has a max of 1000 free invalidations each month)