### PR TITLE
create dynamic routes for all our v1 products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.1",
         "eslint": "8.39.0",
-        "next": "^13.4.0",
+        "next": "^13.4.5-canary.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "5.0.4"
@@ -119,9 +119,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@next/env": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.0.tgz",
-      "integrity": "sha512-LKofmUuxwGXk2OZJSSJ2SlJE62s6z+56aRsze7chc5TPoVouLR9liTiSWxzYuVzuxk0ui2wtIjyR2tcgS1dIyw=="
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5-canary.3.tgz",
+      "integrity": "sha512-2TrPvCIs8R9DpFpEDmGUOpWkVqbpb4+sGQMcZVP4zDYYg893p0nAbNbBxL996oBl+/vLTzcLIDceP5peHsGPzg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.0",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.0.tgz",
-      "integrity": "sha512-C39AGL3ANXA+P3cFclQjFZaJ4RHPmuBhskmyy0N3VyCntDmRrNkS4aXeNY4Xwure9IL1nuw02D8bM55I+FsbuQ==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5-canary.3.tgz",
+      "integrity": "sha512-mUlpzua0RDPLNfNeqi0DzWNCqVzMphNh42BS8PojVO3NPC55+RX9tllQngz+qFAOcLL7g4LgoeE9VWgh31s/WQ==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.0.tgz",
-      "integrity": "sha512-nj6nx6o7rnBXjo1woZFWLk7OUs7y0SQ0k65SX62kc88GqXtYi3BCqbBznjOX8qtrO//NmtAde/Jd5qkjSgINUQ==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5-canary.3.tgz",
+      "integrity": "sha512-0bkYuSFh1/0ZedCVsSMtHiSxdfQxF0BO/v5VwRdOLtOZE8WrQdoXsWiVsiFBOTutiZDhats9exFOFgmymoSqSA==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.0.tgz",
-      "integrity": "sha512-FBYL7kpzI2KG3lv8gO4xVYmWcFohptjzD9RCLdXsAz+Kqz5VCJILF21DoRcz4Nwj/jMe0SO7l5kBVW4POl4EaQ==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5-canary.3.tgz",
+      "integrity": "sha512-+PxhM2E98APKNEl1FCwhqU9ttGRoWsZcPPU20qcKFrJ/fKbfaWDnhzlSiZPmmERISZrmd54Uy3maNq9ys+bz6g==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.0.tgz",
-      "integrity": "sha512-S3htBbcovnLMgVn0z1ThrP1iAeEM43fw8B7S3KyHTAGe0I21ww4rvUkLdgPCqLNvMpv899lmG7NU5rs6rTkGvg==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5-canary.3.tgz",
+      "integrity": "sha512-KMRWPxeoZ41146NHpMAGMtD/RkQt/0QOlL13pREnNjeTzQI6P20X+ra5tHkCQoFB/8xseN9RXnuLMyYG3mYoGw==",
       "cpu": [
         "arm64"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.0.tgz",
-      "integrity": "sha512-H8GhCgQwFl6iWJ6azQ2tG/GY8BUg1nhPtg4Tp2kIPljdyQypTGJe8oRnPDx0N48WWvB2fNeA7LNEwzVuSidH2w==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5-canary.3.tgz",
+      "integrity": "sha512-dwSxDddWMaTAmSPxSWWrwaHHPqLlnNJoc22dTfyQX9Hwecq+Sq2RGSkGicga3z6Z7rX3Nm4MbNduM2GWXwcvgg==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.0.tgz",
-      "integrity": "sha512-mztVybRPY39NfPOA3QrRQKzYuw7A/D8ElR6ruvM1cBsXMEfF5xTzdZqfTtrE/gNTPUFug9FJPpiRpkZ4mDUl8w==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5-canary.3.tgz",
+      "integrity": "sha512-R2SqJsC6QPNxO3t/U2fMouzLfUNLHP8PfZH/XTIwQ12dxZCwUwBg/cNX5ocBtoci3lCYNcOLNjSuc3z9b/yIeQ==",
       "cpu": [
         "x64"
       ],
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.0.tgz",
-      "integrity": "sha512-mdVh/n0QqT2uXqn8kaTywUoLxY1OYqTpiKbt5b51pDwOStqgbIbqBqG0A7XDaiqWa7RKwllOYxPlPm16EDfWUA==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5-canary.3.tgz",
+      "integrity": "sha512-/spv7kDp2xKUJzdvGFU2gf/N1lXtm/E2p/Fx/XreUyajiaT0f57d2mHfDabW5saq3KL3wPlWZ5zW7iDh2Awm+Q==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.0.tgz",
-      "integrity": "sha512-GNRqT2mqxxH0x9VthFqziBj8X8HsoBUougmLe3kOouRq/jF73LpKXG0Qs2MYkylqvv/Wg31EYjFNcJnBi1Nimg==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5-canary.3.tgz",
+      "integrity": "sha512-VIlQ+emO306CYbIyEKu8RTAzmMw/z+akEhu2urZPKjj+UMKCLfq1w4u3GJfURfdRiJ5ws7fLXDHVAjon4G+Ygg==",
       "cpu": [
         "ia32"
       ],
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.0.tgz",
-      "integrity": "sha512-0AkvhUBUqeb4WKN75IW1KjPkN3HazQFA0OpMuTK+6ptJUXMaMwDDcF3sIPCI741BJ2fpODB7BPM4C63hXWEypg==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5-canary.3.tgz",
+      "integrity": "sha512-JSb5haHmRxn2Jysrsw3UJ/mgNu0TD+JJdHyGkdQeGIM4V1Q1G/KgQNCTovWfimd8e1JUoZqSV4aX+y7zEDVkEg==",
       "cpu": [
         "x64"
       ],
@@ -2776,11 +2776,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.0.tgz",
-      "integrity": "sha512-y3E+2ZjiVrphkz7zcJvd2rEG6miOekI8krPfWV4AZZ9TaF0LDuFdP/f+RQ5M9wRvsz6GWw8k8+7jsO860GxSqg==",
+      "version": "13.4.5-canary.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5-canary.3.tgz",
+      "integrity": "sha512-5YLpHWSLjjInYlqxtkZZr7cwYp62wXEm7ik6Wu+4JqWQdbwD/pemuXwErxRIt65ruDQwe9RvE/dzMOuQuNDE+A==",
       "dependencies": {
-        "@next/env": "13.4.0",
+        "@next/env": "13.4.5-canary.3",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -2795,20 +2795,19 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.0",
-        "@next/swc-darwin-x64": "13.4.0",
-        "@next/swc-linux-arm64-gnu": "13.4.0",
-        "@next/swc-linux-arm64-musl": "13.4.0",
-        "@next/swc-linux-x64-gnu": "13.4.0",
-        "@next/swc-linux-x64-musl": "13.4.0",
-        "@next/swc-win32-arm64-msvc": "13.4.0",
-        "@next/swc-win32-ia32-msvc": "13.4.0",
-        "@next/swc-win32-x64-msvc": "13.4.0"
+        "@next/swc-darwin-arm64": "13.4.5-canary.3",
+        "@next/swc-darwin-x64": "13.4.5-canary.3",
+        "@next/swc-linux-arm64-gnu": "13.4.5-canary.3",
+        "@next/swc-linux-arm64-musl": "13.4.5-canary.3",
+        "@next/swc-linux-x64-gnu": "13.4.5-canary.3",
+        "@next/swc-linux-x64-musl": "13.4.5-canary.3",
+        "@next/swc-win32-arm64-msvc": "13.4.5-canary.3",
+        "@next/swc-win32-ia32-msvc": "13.4.5-canary.3",
+        "@next/swc-win32-x64-msvc": "13.4.5-canary.3"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
         "fibers": ">= 3.1.0",
-        "node-sass": "^6.0.0 || ^7.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "sass": "^1.3.0"
@@ -2818,9 +2817,6 @@
           "optional": true
         },
         "fibers": {
-          "optional": true
-        },
-        "node-sass": {
           "optional": true
         },
         "sass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@types/react": "18.2.0",
         "@types/react-dom": "18.2.1",
         "eslint": "8.39.0",
-        "next": "^13.4.5-canary.3",
+        "next": "^13.4.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "typescript": "5.0.4"
@@ -119,9 +119,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@next/env": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.5-canary.3.tgz",
-      "integrity": "sha512-2TrPvCIs8R9DpFpEDmGUOpWkVqbpb4+sGQMcZVP4zDYYg893p0nAbNbBxL996oBl+/vLTzcLIDceP5peHsGPzg=="
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.4.tgz",
+      "integrity": "sha512-q/y7VZj/9YpgzDe64Zi6rY1xPizx80JjlU2BTevlajtaE3w1LqweH1gGgxou2N7hdFosXHjGrI4OUvtFXXhGLg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "13.4.0",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5-canary.3.tgz",
-      "integrity": "sha512-mUlpzua0RDPLNfNeqi0DzWNCqVzMphNh42BS8PojVO3NPC55+RX9tllQngz+qFAOcLL7g4LgoeE9VWgh31s/WQ==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.4.tgz",
+      "integrity": "sha512-xfjgXvp4KalNUKZMHmsFxr1Ug+aGmmO6NWP0uoh4G3WFqP/mJ1xxfww0gMOeMeSq/Jyr5k7DvoZ2Pv+XOITTtw==",
       "cpu": [
         "arm64"
       ],
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.5-canary.3.tgz",
-      "integrity": "sha512-0bkYuSFh1/0ZedCVsSMtHiSxdfQxF0BO/v5VwRdOLtOZE8WrQdoXsWiVsiFBOTutiZDhats9exFOFgmymoSqSA==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.4.tgz",
+      "integrity": "sha512-ZY9Ti1hkIwJsxGus3nlubIkvYyB0gNOYxKrfsOrLEqD0I2iCX8D7w8v6QQZ2H+dDl6UT29oeEUdDUNGk4UEpfg==",
       "cpu": [
         "x64"
       ],
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.5-canary.3.tgz",
-      "integrity": "sha512-+PxhM2E98APKNEl1FCwhqU9ttGRoWsZcPPU20qcKFrJ/fKbfaWDnhzlSiZPmmERISZrmd54Uy3maNq9ys+bz6g==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.4.tgz",
+      "integrity": "sha512-+KZnDeMShYkpkqAvGCEDeqYTRADJXc6SY1jWXz+Uo6qWQO/Jd9CoyhTJwRSxvQA16MoYzvILkGaDqirkRNctyA==",
       "cpu": [
         "arm64"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.5-canary.3.tgz",
-      "integrity": "sha512-KMRWPxeoZ41146NHpMAGMtD/RkQt/0QOlL13pREnNjeTzQI6P20X+ra5tHkCQoFB/8xseN9RXnuLMyYG3mYoGw==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.4.tgz",
+      "integrity": "sha512-evC1twrny2XDT4uOftoubZvW3EG0zs0ZxMwEtu/dDGVRO5n5pT48S8qqEIBGBUZYu/Xx4zzpOkIxx1vpWdE+9A==",
       "cpu": [
         "arm64"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.5-canary.3.tgz",
-      "integrity": "sha512-dwSxDddWMaTAmSPxSWWrwaHHPqLlnNJoc22dTfyQX9Hwecq+Sq2RGSkGicga3z6Z7rX3Nm4MbNduM2GWXwcvgg==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.4.tgz",
+      "integrity": "sha512-PX706XcCHr2FfkyhP2lpf+pX/tUvq6/ke7JYnnr0ykNdEMo+sb7cC/o91gnURh4sPYSiZJhsF2gbIqg9rciOHQ==",
       "cpu": [
         "x64"
       ],
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.5-canary.3.tgz",
-      "integrity": "sha512-R2SqJsC6QPNxO3t/U2fMouzLfUNLHP8PfZH/XTIwQ12dxZCwUwBg/cNX5ocBtoci3lCYNcOLNjSuc3z9b/yIeQ==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.4.tgz",
+      "integrity": "sha512-TKUUx3Ftd95JlHV6XagEnqpT204Y+IsEa3awaYIjayn0MOGjgKZMZibqarK3B1FsMSPaieJf2FEAcu9z0yT5aA==",
       "cpu": [
         "x64"
       ],
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.5-canary.3.tgz",
-      "integrity": "sha512-/spv7kDp2xKUJzdvGFU2gf/N1lXtm/E2p/Fx/XreUyajiaT0f57d2mHfDabW5saq3KL3wPlWZ5zW7iDh2Awm+Q==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.4.tgz",
+      "integrity": "sha512-FP8AadgSq4+HPtim7WBkCMGbhr5vh9FePXiWx9+YOdjwdQocwoCK5ZVC3OW8oh3TWth6iJ0AXJ/yQ1q1cwSZ3A==",
       "cpu": [
         "arm64"
       ],
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.5-canary.3.tgz",
-      "integrity": "sha512-VIlQ+emO306CYbIyEKu8RTAzmMw/z+akEhu2urZPKjj+UMKCLfq1w4u3GJfURfdRiJ5ws7fLXDHVAjon4G+Ygg==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.4.tgz",
+      "integrity": "sha512-3WekVmtuA2MCdcAOrgrI+PuFiFURtSyyrN1I3UPtS0ckR2HtLqyqmS334Eulf15g1/bdwMteePdK363X/Y9JMg==",
       "cpu": [
         "ia32"
       ],
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.5-canary.3.tgz",
-      "integrity": "sha512-JSb5haHmRxn2Jysrsw3UJ/mgNu0TD+JJdHyGkdQeGIM4V1Q1G/KgQNCTovWfimd8e1JUoZqSV4aX+y7zEDVkEg==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.4.tgz",
+      "integrity": "sha512-AHRITu/CrlQ+qzoqQtEMfaTu7GHaQ6bziQln/pVWpOYC1wU+Mq6VQQFlsDtMCnDztPZtppAXdvvbNS7pcfRzlw==",
       "cpu": [
         "x64"
       ],
@@ -2776,11 +2776,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "13.4.5-canary.3",
-      "resolved": "https://registry.npmjs.org/next/-/next-13.4.5-canary.3.tgz",
-      "integrity": "sha512-5YLpHWSLjjInYlqxtkZZr7cwYp62wXEm7ik6Wu+4JqWQdbwD/pemuXwErxRIt65ruDQwe9RvE/dzMOuQuNDE+A==",
+      "version": "13.4.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.4.4.tgz",
+      "integrity": "sha512-C5S0ysM0Ily9McL4Jb48nOQHT1BukOWI59uC3X/xCMlYIh9rJZCv7nzG92J6e1cOBqQbKovlpgvHWFmz4eKKEA==",
       "dependencies": {
-        "@next/env": "13.4.5-canary.3",
+        "@next/env": "13.4.4",
         "@swc/helpers": "0.5.1",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001406",
@@ -2795,15 +2795,15 @@
         "node": ">=16.8.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "13.4.5-canary.3",
-        "@next/swc-darwin-x64": "13.4.5-canary.3",
-        "@next/swc-linux-arm64-gnu": "13.4.5-canary.3",
-        "@next/swc-linux-arm64-musl": "13.4.5-canary.3",
-        "@next/swc-linux-x64-gnu": "13.4.5-canary.3",
-        "@next/swc-linux-x64-musl": "13.4.5-canary.3",
-        "@next/swc-win32-arm64-msvc": "13.4.5-canary.3",
-        "@next/swc-win32-ia32-msvc": "13.4.5-canary.3",
-        "@next/swc-win32-x64-msvc": "13.4.5-canary.3"
+        "@next/swc-darwin-arm64": "13.4.4",
+        "@next/swc-darwin-x64": "13.4.4",
+        "@next/swc-linux-arm64-gnu": "13.4.4",
+        "@next/swc-linux-arm64-musl": "13.4.4",
+        "@next/swc-linux-x64-gnu": "13.4.4",
+        "@next/swc-linux-x64-musl": "13.4.4",
+        "@next/swc-win32-arm64-msvc": "13.4.4",
+        "@next/swc-win32-ia32-msvc": "13.4.4",
+        "@next/swc-win32-x64-msvc": "13.4.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.1",
     "eslint": "8.39.0",
-    "next": "^13.4.0",
+    "next": "^13.4.5-canary.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.0.4"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.1",
     "eslint": "8.39.0",
-    "next": "^13.4.5-canary.3",
+    "next": "^13.4.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "5.0.4"

--- a/src/app/items/[id]/page.tsx
+++ b/src/app/items/[id]/page.tsx
@@ -1,0 +1,11 @@
+import {Graph} from "@/Components/Graphs/Graph";
+import {PageContent} from "@/Components/page/PageContent";
+import React from "react";
+
+export default function Item({ params }: { params: { id: string } }): JSX.Element {
+    return (
+        <PageContent>
+            <Graph inName={params.id} />
+        </PageContent>
+    )
+}

--- a/src/app/items/[id]/products.ts
+++ b/src/app/items/[id]/products.ts
@@ -1,0 +1,40 @@
+
+interface LinkProps {
+    name: string,
+    link: string,
+}
+
+export const productRoutes: LinkProps[] = [
+    {
+        name: "270 Free Standing Awning",
+        link: "/items/270_Free-Standing_Awning",
+    },
+    {
+        name: "30L Drawer Fridge Freezer",
+        link: "/items/30L_Drawer_Fridge_Freezer",
+    },
+    {
+        name: "Kings 200Ah Lithium LiFePO4 Battery",
+        link: "/items/Kings_200Ah_Lithium_LiFePO4_Battery",
+    },
+    {
+        name: "Kings Big Daddy Deluxe Double Swag",
+        link: "/items/Kings_Big_Daddy_Deluxe_Double_Swag",
+    },
+    {
+        name: "Kings 40A DCDC Charger | Quick Connect Plugs",
+        link: "/items/Kings_40A_DCDC_Charger_|_Quick_Connect_Plugs",
+    },
+    {
+        name: "Kings 2x3m Side Awning",
+        link: "/items/Kings_2x3m_Side_Awning",
+    },
+    {
+        name: "Domin8r X 12,000lb Winch | 5.7hp Motor",
+        link: "/items/Domin8r_X_12,000lb_Winch_|_5.7hp_Motor",
+    },
+    {
+        name: "30L Drawer Fridge Freezer",
+        link: "/items/30L_Drawer_Fridge_Freezer",
+    }
+]

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import {Graph} from "@/Components/Graphs/Graph";
 import {PageContent} from "@/Components/page/PageContent";
+import Link from "next/link";
+import {productRoutes} from "@/app/items/[id]/products";
 
 export const metadata = {
     title: "Items - Price Mates",
@@ -10,7 +11,16 @@ export const metadata = {
 export default function Items(): JSX.Element {
     return (
         <PageContent>
-            <Graph inName="270_Free-Standing_Awning" />
+            <h2>All products we currently track</h2>
+            <p>If a product you like is not on the list below, please let us know <Link href={"/contact-us"}>here!</Link></p>
+            <br/>
+            {productRoutes.map((link, index) => {
+                return (
+                    <div key={index}>
+                        <Link href={link.link}><h2>{link.name}</h2></Link>
+                    </div>
+                    )}
+            )}
         </PageContent>
     );
 }


### PR DESCRIPTION
adds dynamic `[id]` routes for the products we track. this page and path is still not in use and is just for local testing we still need to setup the back end in AWS to connect the live version to once I have made some more adjustments to the scrapper I will look at deploying it in the next few weeks
